### PR TITLE
update README add instruction to persist blockchain data

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,3 +6,12 @@ docker run -it
 ```
 docker run -it --fast --rpc --rpc-domain 0.0.0.0
 ```
+
+## Using Volumes
+To persist downloaded blockchain data between container starts, use Docker [volumes](https://docs.docker.com/storage/volumes/).
+
+```
+docker volume create ethereum-classic
+
+docker run -it -v ethereum-classic:/root/.ethereum-classic <name of etc image>
+```


### PR DESCRIPTION
Include instructions to persist downloaded blockchain between container starts.

How to test:
```
docker build -t geth .

docker volume create ethereum-classic

# Start container on testnet
docker run -it --rm --name etc -v ethereum-classic:/root/.ethereum-classic geth --chain=morden

# Shut down container and restart, this time on mainnet
docker run -it --rm --name etc -v ethereum-classic:/root/.ethereum-classic geth

# In another terminal
docker exec -it etc bash

ls /root/.ethereum-classic/
# should output folders for mainet and morden
```